### PR TITLE
Implemented genric helper methods for interacting with unexposed api.

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,24 @@ For actual examples see the tests source code. Note that `routes` and `lists` AP
    * `.create(listAddress, data)` - create a mailing list member. `data` should contain `address`, optional member `name`, `subscribed`, `upsert`, and any additional `vars`.
    * `.update(listAddress, memberAddress, data)` - update a mailing list member with given properties. Won't touch the property if it's not passed in.
    * `.del(listAddress, memberAddress)` - delete a mailing list member given mailing list address and member address.
+* `mailgun._get(resource,data,callback)` - sends GET request to the specified resource on api.
+* `mailgun._post(resource,data,callback)` - sends POST request to the specified resource on api.
+* `mailgun._del(resource,data,callback)` - sends DELETE request to the specified resource on api.
+* `mailgun._put(resource,data,callback)` - sends PUT request to the specified resource on api.
 
+### Unexposed API Methods
+
+Mailgun-js also provides helper methods to allow users to interact with parts of the api that are not exposed already.
+
+Example: Get All Stats
+
+```js
+  
+mailgun._get('/stats', function (error, response, body) {
+  console.log(body);
+});
+
+```
 
 ## Tests
 

--- a/mailgun.js
+++ b/mailgun.js
@@ -115,6 +115,21 @@ module.exports = function (api_key, domain) {
   }
 
   return {
+
+    /**
+     * Expose helper methods to allow users to interact with parts of the api that
+     * are not exposed already.
+     *
+     * Example
+     *  mailgun._get('/stats',function(err,stats){
+     *    console.log(stats)
+     *  })
+     */
+    _post : post,
+    _get : get,
+    _del : del,
+    _put : put,
+
     messages: {
       /**
        * Creates a new email message and sends it using mailgun


### PR DESCRIPTION
Exposed the get/post/del/put methods on exported object. This will allow users to interact with parts of mailgun's protocol that are not exposed through the current helper methods. For example getting /stats.

Documented it in readme as well.
