### PR TITLE
added querystring

### DIFF
--- a/mailgun.js
+++ b/mailgun.js
@@ -62,15 +62,13 @@ module.exports = function (api_key, domain) {
 
     var qsdata = qs.stringify(data);
     
-    if (method === 'GET' || method === 'DELETE') {
-    	path += '?' + qsdata;
-    }
-
+    var headers = {};
+    
     if (method === 'GET' || method === 'DELETE') {
       path = path.concat('?', qsdata);
     }
     else {
-      var headers = {
+      headers = {
         'Content-Type': 'application/x-www-form-urlencoded',
         'Content-Length': qsdata.length
       };


### PR DESCRIPTION
I'm using mailgun-js, this is awesome, but don't possible pass querystring.
This is bad hehe, i need it for get stats data.
I searched on the issues, and found, but has now been removed.

Done in a way that had on a pull request.
