### PR TITLE
Implement API methods for campaign management.

### DIFF
--- a/docs/campaign.md
+++ b/docs/campaign.md
@@ -1,0 +1,56 @@
+# campaign
+
+Manage campaigns. See http://documentation.mailgun.com/api-campaigns.html
+
+## Actions
+
+### `create`
+
+Create a new campaign.
+
+`mailgun.campaigns().create({attributes}, {callback});`
+
+Method | Path
+--- | ---
+POST | /campaigns
+
+### `list`
+
+Returns a list of campaigns.
+
+`mailgun.campaigns().list({callback});`
+
+Method | Path
+--- | ---
+GET | /campaigns
+
+### `info`
+
+Get single campaign info.
+
+`mailgun.campaigns({id}).info({callback});`
+
+Method | Path
+--- | ---
+GET | /campaigns/{id}
+
+### `update`
+
+Update campaign.
+
+`mailgun.campaigns({id}).update({attributes}, {callback});`
+
+Method | Path
+--- | ---
+PUT | /campaigns/{id}
+
+### `delete`
+
+Delete campaign.
+
+`mailgun.campaigns({id}).delete({callback});`
+
+Method | Path
+--- | ---
+DELETE | /campaigns/{id}
+

--- a/lib/request.js
+++ b/lib/request.js
@@ -141,7 +141,10 @@ Request.prototype.handleResponse = function (res) {
   res.on('end', function () {
     var body;
 
-    if (!error && res.headers['content-type'].indexOf('application/json') >= 0) {
+    // FIXME: An ugly hack to overcome invalid response type in mailgun api (see http://bit.ly/1eF30fU).
+    // We skip content-type validation for 'campaings' endpoint assuming it is JSON.
+    var skipContentTypeCheck = res.req.path.match(/\/campaigns/);
+    if (!error && (skipContentTypeCheck || (res.headers['content-type'].indexOf('application/json') >= 0))) {
       try {
         body = JSON.parse(chunks);
       }

--- a/lib/schema.js
+++ b/lib/schema.js
@@ -451,6 +451,66 @@ module.exports = {
           "title": "delete"
         }
       ]
+    },
+    "campaign": {
+      "description": "Manage campaigns. See http://documentation.mailgun.com/api-campaigns.html",
+      "links": [
+        {
+          "description": "Create a new campaign.",
+          "href": "/campaigns",
+          "method": "POST",
+          "title": "create",
+          "properties": {
+            "id": {
+              "type": "string"
+            },
+            "name": {
+              "type": "string"
+            }
+          },
+          "required": ["name"]
+        },
+        {
+          "description": "Returns a list of campaigns.",
+          "href": "/campaigns",
+          "method": "GET",
+          "title": "list"
+        },
+        {
+          "description": "Get single campaign info.",
+          "href": "/campaigns/{id}",
+          "method": "GET",
+          "title": "info"
+        },
+        {
+          "description": "Update campaign.",
+          "href": "/campaigns/{id}",
+          "method": "PUT",
+          "title": "update",
+          "properties": {
+            "id": {
+              "type": "string"
+            },
+            "name": {
+              "type": "string"
+            }
+          }
+        },
+        {
+          "description": "Delete campaign.",
+          "href": "/campaigns/{id}",
+          "method": "DELETE",
+          "title": "delete",
+          "properties": {
+            "limit": {
+              "type": "number"
+            },
+            "skip": {
+              "type": "number"
+            }
+          }
+        }
+      ]
     }
   }
 };

--- a/test/fixture.json
+++ b/test/fixture.json
@@ -32,5 +32,10 @@
   },
   "bounce": {
     "address":"me@test.mailgun.org"
+  },
+  "campaign": {
+    "name": "My test campaign",
+    "id": "mu_uniq_campaign_id",
+    "newName": "my_new_campaign_name"
   }
 }

--- a/test/mailgun.test.js
+++ b/test/mailgun.test.js
@@ -753,5 +753,86 @@ module.exports = {
       assert.ok(body.items);
       done();
     });
+  },
+
+  /*
+   * Campaigns
+   */
+
+  'test campaigns().create() invalid missing address': function (done) {
+    mailgun.campaigns().create({}, function (err) {
+      assert.ok(err);
+      assert(/Missing parameter 'name'/.test(err.message));
+      done();
+    });
+  },
+
+  'test campaigns().create()': function (done) {
+    mailgun.campaigns().create(fixture.campaign, function (err, body) {
+      assert.ifError(err);
+      assert.ok(body);
+      assert.ok(body.message);
+      assert.ok(body.campaign);
+      assert.equal(fixture.campaign.name, body.campaign.name);
+      assert.equal(fixture.campaign.id, body.campaign.id);
+      done();
+    });
+  },
+
+
+  'test campaigns().list() with invalid `limit` param': function (done) {
+    mailgun.campaigns().list({limit: "foo"}, function (err, body) {
+      assert.ok(err);
+      assert(/'limit' parameter is not an integer/.test(err.message));
+      done();
+    });
+  },
+
+  'test campaigns().list() with invalid `skip` param': function (done) {
+    mailgun.campaigns().list({skip: "bar"}, function (err, body) {
+      assert.ok(err);
+      assert(/'skip' parameter is not an integer/.test(err.message));
+      done();
+    });
+  },
+
+  'test campaigns().list()': function (done) {
+    mailgun.campaigns().list(function (err, body) {
+      assert.ifError(err);
+      assert.ok(body);
+      assert.ok(body.total_count);
+      assert.ok(body.items);
+      done();
+    });
+  },
+
+  'test campaigns().info()': function (done) {
+    mailgun.campaigns(fixture.campaign.id).info(function (err, body) {
+      assert.ifError(err);
+      assert.ok(body);
+      assert.equal(fixture.campaign.id, body.id);
+      assert.equal(fixture.campaign.name, body.name);
+      done();
+    });
+  },
+
+  'test campaigns().update()': function (done) {
+    mailgun.campaigns(fixture.campaign.id).update({name: fixture.campaign.newName}, function (err, body) {
+      assert.ifError(err);
+      assert.ok(body);
+      assert.ok(body.message);
+      assert.ok(body.campaign);
+      assert.equal(fixture.campaign.newName, body.campaign.name);
+      done();
+    });
+  },
+
+  'test campaigns().delete()': function (done) {
+    mailgun.campaigns(fixture.campaign.id).delete(function (err, body) {
+      assert.ifError(err);
+      assert.ok(body);
+      assert.ok(body.message);
+      done();
+    });
   }
 };


### PR DESCRIPTION
This pull requests adds methods for campaign management (http://documentation.mailgun.com/api-campaigns.html), a feature recently added in Mailgun.

Implemented methods:
    - create campaign
    - list campaigns
    - get campaign info
    - update campaign
    - delete campaign

IMPORTANT: Because of a Mailgun API issue with content type (more here: http://bit.ly/1eF30fU) I had to add a hack in response handling. Basically lib now skips content type validation and assumes the response is in JSON format for Campaigns endpoint (only).
