### PR TITLE
Only walk local keys of resources object

### DIFF
--- a/lib/build.js
+++ b/lib/build.js
@@ -10,10 +10,11 @@ var Builder = function (baseObj, resources) {
 };
 
 Builder.prototype.build = function () {
-  for (var key in this.resources) {
+  var self = this;
+  Object.keys(this.resources).forEach(function (key) {
     //console.log('building ' + key);
-    this.buildResource(this.resources[key]);
-  }
+  	self.buildResource(self.resources[key]);
+  });
 };
 
 Builder.prototype.buildResource = function (resource) {


### PR DESCRIPTION
Using for...in walks the Object prototype in addition to local keys which is bad in this case if you've added stuff to Object. Using Object.keys() instead avoids this issue.
