### PR TITLE
support passing in filename option for file attachments

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,8 +120,8 @@ mailgun.messages().send(data, function (error, body) {
 });
 ```
 
-Finally we provide a `Mailgun.Attachment` class to add attachment and specify both the buffer and filename data.
-
+Finally we provide a `Mailgun.Attachment` class to add attachment and specify both the data source and filename.
+The first constructor argument can be either a `Buffer` or a `string` (file path).
 ```js
 var filename = '/mailgun_logo.png';
 var filepath = path.join(__dirname, filename);

--- a/lib/attachment.js
+++ b/lib/attachment.js
@@ -5,7 +5,7 @@
  * @constructor
  */
 function Attachment(data, filename) {
-  if (Buffer.isBuffer(data)) {
+  if (typeof data === 'string' || Buffer.isBuffer(data)) {
     this.data = data;
   }
   this.filename = filename;

--- a/lib/request.js
+++ b/lib/request.js
@@ -126,7 +126,10 @@ Request.prototype.handleAttachmentObject = function (key, obj) {
     this.form.append(key, fs.createReadStream(obj));
   }
   else if ((typeof obj === 'object') && (obj instanceof Attachment)) {
-    if (obj.data && Buffer.isBuffer(obj.data)) {
+    if (typeof obj.data === 'string') {
+      this.form.append(key, fs.createReadStream(obj.data), {filename: obj.filename || 'file'});
+    }
+    else if (Buffer.isBuffer(obj.data)) {
       this.form.append(key, obj.data, {filename: obj.filename || 'file'});
     }
   }

--- a/test/mailgun.test.js
+++ b/test/mailgun.test.js
@@ -81,7 +81,7 @@ module.exports = {
     });
   },
 
-  'test messages().send() with attachment using Attachment object': function (done) {
+  'test messages().send() with attachment using Attachment object (Buffer)': function (done) {
     var msg = fixture.message;
 
     var filename = '/mailgun_logo.png';
@@ -89,6 +89,23 @@ module.exports = {
     var file = fs.readFileSync(filepath);
 
     msg.attachment = new Mailgun.Attachment(file, filename);
+
+    mailgun.messages().send(msg, function (err, body) {
+      assert.ifError(err);
+      assert.ok(body.id);
+      assert.ok(body.message);
+      assert(/Queued. Thank you./.test(body.message));
+      done();
+    });
+  },
+
+  'test messages().send() with attachment using Attachment object (file)': function (done) {
+    var msg = fixture.message;
+
+    var filename = '/mailgun_logo.png';
+    var filepath = path.join(__dirname, filename);
+
+    msg.attachment = new Mailgun.Attachment(filepath, 'my_custom_name.png');
 
     mailgun.messages().send(msg, function (err, body) {
       assert.ifError(err);
@@ -161,7 +178,7 @@ module.exports = {
     });
   },
 
-  'test messages().send() with attachment using Attachment object': function (done) {
+  'test messages().send() with inline attachment using Attachment object (Buffer)': function (done) {
     var msg = fixture.message;
 
     var filename = '/mailgun_logo.png';
@@ -169,6 +186,23 @@ module.exports = {
     var file = fs.readFileSync(filepath);
 
     msg.inline = new Mailgun.Attachment(file, filename);
+
+    mailgun.messages().send(msg, function (err, body) {
+      assert.ifError(err);
+      assert.ok(body.id);
+      assert.ok(body.message);
+      assert(/Queued. Thank you./.test(body.message));
+      done();
+    });
+  },
+
+  'test messages().send() with inline attachment using Attachment object (file)': function (done) {
+    var msg = fixture.message;
+
+    var filename = '/mailgun_logo.png';
+    var filepath = path.join(__dirname, filename);
+
+    msg.inline = new Mailgun.Attachment(filepath, 'my_custom_name.png');
 
     mailgun.messages().send(msg, function (err, body) {
       assert.ifError(err);


### PR DESCRIPTION
Hello,

I need to attach files to mails with a different name than the filesystem one.  I initially thought that it was possible but only `Buffer` type objects are supported in `Mailgun.Attachment`. This change allows passing either a file path or a `Buffer`.

As a side note, it would be really cool to directly send streams (from database) as attachments.

Regards
