### PR TITLE
Don't throw if res.req.path isn't defined.

### DIFF
--- a/lib/request.js
+++ b/lib/request.js
@@ -166,7 +166,7 @@ Request.prototype.handleResponse = function (res) {
 
     // FIXME: An ugly hack to overcome invalid response type in mailgun api (see http://bit.ly/1eF30fU).
     // We skip content-type validation for 'campaings' endpoint assuming it is JSON.
-    var skipContentTypeCheck = res.req.path.match(/\/campaigns/);
+    var skipContentTypeCheck = res.req && res.req.path && res.req.path.match(/\/campaigns/);
     if (!error && (skipContentTypeCheck || (res.headers['content-type'].indexOf('application/json') >= 0))) {
       try {
         body = JSON.parse(chunks);


### PR DESCRIPTION
I’m using [node-replay](https://github.com/assaf/node-replay) to mock http requests / responses from mailgun when testing. Replay’s proxied `res` object doesn’t have a `req` property, so this line throws. This PR fixes this case. Generally, I think it couldn't hurt to check if the property exists. The Node docs don’t mention HttpResponse having a `req` so perhaps it is best not to rely on it existing.
